### PR TITLE
Leave deps alone

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,8 +94,6 @@
   },
   "devDependencies": {
     "@eth-optimism/contracts-bedrock": "^0.17.2",
-    "@hyperlane-xyz/registry": "^4.2.0",
-    "@hyperlane-xyz/sdk": "^5.1.0",
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.2",
     "@nomicfoundation/hardhat-ethers": "^3.0.5",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.10",
@@ -105,8 +103,6 @@
     "@nomiclabs/hardhat-ethers": "^2.2.3",
     "@nomiclabs/hardhat-etherscan": "^3.1.8",
     "@nomiclabs/hardhat-waffle": "^2.0.6",
-    "@openzeppelin/contracts": "^5.0.2",
-    "@openzeppelin/contracts-upgradeable": "^5.0.2",
     "@openzeppelin/hardhat-upgrades": "^3.2.0",
     "@typechain/ethers-v6": "^0.5.1",
     "@typechain/hardhat": "^9.1.0",
@@ -146,5 +142,11 @@
     "typechain": "^8.3.2",
     "typescript": ">=4.5.0",
     "viem": "^2.0.0"
+  },
+  "dependencies": {
+    "@hyperlane-xyz/registry": "^4.2.0",
+    "@hyperlane-xyz/sdk": "^5.1.0",
+    "@openzeppelin/contracts": "^5.0.2",
+    "@openzeppelin/contracts-upgradeable": "^5.0.2"
   }
 }


### PR DESCRIPTION
The deps in the package are required in the published package for solidity build of the .sol files
For a leaner npm package, we need to add a new package deploy pack type like `@eco_foundation/routes/core` or something

Revert "move dependencies to devDependencies to reduce bundle size (#…108)"

This reverts commit 4ff5595fd0fef5f181324607b6232066d8b3697e.